### PR TITLE
chore!: increase minimum required version of node from 12 to 14

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
 	env: {
-		es2021: true,
+		es2020: true,
 		node: true,
 	},
 	extends: [
@@ -12,6 +12,7 @@ module.exports = {
 		"prettier",
 	],
 	parserOptions: {
+		ecmaVersion: 2020,
 		sourceType: "module",
 		ecmaFeatures: {
 			impliedStrict: true,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
         if: github.event.pull_request.draft == false
         strategy:
             matrix:
-                node: [12, 14, 16]
+                node: [14, 16]
                 os: [macos-latest, ubuntu-latest, windows-latest]
         runs-on: ${{ matrix.os }}
         steps:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "author": "Frazer Smith <frazer.smith@ydh.nhs.uk>",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "scripts": {
     "benchmark": "autocannon -H \"Authorization:Bearer testtoken\" \"http://0.0.0.0:8204/preferences/options\"",


### PR DESCRIPTION
BREAKING CHANGE: minimum required version of node increased from 12 to 14 to allow for new ECMAScript syntax to be used