### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -4,7 +4,8 @@
 		// "checkJs": true,
 		// "strict": true,
 		"lib": ["ES2022"],
-		"moduleResolution": "nodenext",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
 		"resolveJsonModule": true,
 		"target": "ES2022"
 	},

--- a/scripts/license-checker.js
+++ b/scripts/license-checker.js
@@ -3,7 +3,7 @@
 
 "use strict";
 
-const { promisify } = require("util");
+const { promisify } = require("node:util");
 const { init } = require("license-checker");
 // @ts-ignore
 const copyLeftLicenses = require("spdx-copyleft");

--- a/src/config/config.test.js
+++ b/src/config/config.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { unlink } = require("fs/promises");
+const { unlink } = require("node:fs/promises");
 const { glob } = require("glob");
 const getConfig = require(".");
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -2,7 +2,7 @@
 
 require("dotenv").config();
 
-const { readFile } = require("fs/promises");
+const { readFile } = require("node:fs/promises");
 const envSchema = require("env-schema");
 const { getStream } = require("file-stream-rotator");
 const S = require("fluent-json-schema").default;

--- a/src/routes/admin/access/bearer-token/index.js
+++ b/src/routes/admin/access/bearer-token/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { randomUUID } = require("crypto");
+const { randomUUID } = require("node:crypto");
 const { hash: bcryptHash } = require("bcryptjs");
 const { parse: secureParse } = require("secure-json-parse");
 

--- a/src/routes/admin/access/bearer-token/route.test.js
+++ b/src/routes/admin/access/bearer-token/route.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { randomUUID } = require("crypto");
+const { randomUUID } = require("node:crypto");
 const Fastify = require("fastify");
 const sensible = require("@fastify/sensible");
 const route = require(".");

--- a/src/server.test.js
+++ b/src/server.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { randomUUID } = require("crypto");
+const { randomUUID } = require("node:crypto");
 const { hashSync } = require("bcryptjs");
 const { chromium, firefox } = require("playwright");
 const Fastify = require("fastify");


### PR DESCRIPTION
See https://github.com/nodejs/node/pull/37246/files#r588397158